### PR TITLE
Filter AC sections when order of solutions at end does not change

### DIFF
--- a/include/HelixSolver/Constants.h
+++ b/include/HelixSolver/Constants.h
@@ -30,3 +30,6 @@ static constexpr uint32_t MAX_SECTIONS_BUFFER_SIZE = 40; // need to be checked e
 // Additional parameters
 static constexpr float MAGNETIC_INDUCTION = 2.0;
 static constexpr float INVERSE_A = 1.0/3.0e-4;
+
+
+static constexpr bool DO_LINE_CROSS_FILTERING = false;


### PR DESCRIPTION
This PR adds code to filter AC sections based on order of solutions. 
It is controlled by a constant `DO_LINE_CROSS_FILTERING` and is off by default.
FI @sh76909 