### PR TITLE
Implemented splitting into regions

### DIFF
--- a/include/HelixSolver/AdaptiveHoughGpuKernel.h
+++ b/include/HelixSolver/AdaptiveHoughGpuKernel.h
@@ -31,13 +31,22 @@ namespace HelixSolver
         SYCL_EXTERNAL void operator()(Index2D idx) const;
 
     private:
-        void fillAccumulatorSection(AccumulatorSection *sectionsStack, uint8_t &sectionsHeight) const;
-        uint8_t countHits(AccumulatorSection &section) const;
-        void addSolution(const AccumulatorSection& section) const;
-        void fillPreciseSolution(const AccumulatorSection& section, SolutionCircle& s) const;
+        // data structure for region data
+        struct RegionData {
+            float one_over_RA[MAX_SP_PER_REGION];
+            float phi[MAX_SP_PER_REGION];
+            // TODO add z as well or index to the measurement in global memory
+            uint16_t spInRegion = 0;
+        };
+
+        void fillAccumulatorSection(const RegionData& data, AccumulatorSection *sectionsStack, uint8_t &sectionsHeight) const;
+        uint8_t countHits(const RegionData& data, AccumulatorSection &section) const;
+        void addSolution(const RegionData& data, const AccumulatorSection& section) const;
+        void fillPreciseSolution(const RegionData& data, const AccumulatorSection& section, SolutionCircle& s) const;
 
         FloatBufferReadAccessor rs;
         FloatBufferReadAccessor phis;
+        FloatBufferReadAccessor zs;
         SolutionsWriteAccessor solutions;
     };
 

--- a/include/HelixSolver/Constants.h
+++ b/include/HelixSolver/Constants.h
@@ -22,10 +22,14 @@ static constexpr float ACC_X_PRECISION = 0.001;
 static constexpr float ACC_Y_PRECISION = 0.01; // this is simplified approach, in reality it could be modified it depending on q/pt
 
 // Initial division parameters
-//static constexpr uint8_t ADAPTIVE_KERNEL_INITIAL_DIVISION_LEVEL = 20; // this gives parallelism
-static constexpr uint8_t ADAPTIVE_KERNEL_INITIAL_DIVISIONS = 1; // this is easier to debug
+// static constexpr uint8_t ADAPTIVE_KERNEL_INITIAL_DIVISIONS = 20;
+static constexpr uint8_t REGIONS_IN_PHI = 10; // set to one for easier debugging
+static constexpr uint8_t REGIONS_IN_ETA = 9; //
+
 
 static constexpr uint32_t MAX_SECTIONS_BUFFER_SIZE = 40; // need to be checked experimentally
+
+static constexpr uint16_t MAX_SP_PER_REGION = 30000; // will need to reduce it depending on number of splits
 
 // Additional parameters
 static constexpr float MAGNETIC_INDUCTION = 2.0;

--- a/include/HelixSolver/ZPhiPartitioning.h
+++ b/include/HelixSolver/ZPhiPartitioning.h
@@ -44,9 +44,7 @@ struct Wedge {
      * @brief returns true if the the point given as an argument is above bottom line
      */
     bool above(float r, float z) const;
-
-
 };
 
-
+Reg region(float min, float max, uint8_t index, uint8_t splits );
 

--- a/src/ComputingWorker.cpp
+++ b/src/ComputingWorker.cpp
@@ -84,8 +84,8 @@ namespace HelixSolver
     // in pure CPU code we do not wait for anything
     solutions = std::make_unique<std::vector<SolutionCircle>>(MAX_SOLUTIONS);
     AdaptiveHoughGpuKernel kernel(*eventBuffer->getRBuffer(), *eventBuffer->getPhiBuffer(), *eventBuffer->getZBuffer(), *solutions);
-    for ( uint8_t div1 = 0; div1 < ADAPTIVE_KERNEL_INITIAL_DIVISIONS; ++div1 ) {
-        for ( uint8_t div2 = 0; div2 < ADAPTIVE_KERNEL_INITIAL_DIVISIONS; ++div2 ) {
+    for ( uint8_t div1 = 0; div1 < REGIONS_IN_PHI; ++div1 ) {
+        for ( uint8_t div2 = 0; div2 < REGIONS_IN_ETA; ++div2 ) {
             kernel({div1, div2});
         }
     }

--- a/src/ZPhiPartitioning.cpp
+++ b/src/ZPhiPartitioning.cpp
@@ -21,12 +21,12 @@ float phi_dist ( float phi1, float phi2 ) {
 }
 
 
-Wedge::Wedge( Reg p, Reg z, Reg eta) 
-    : m_phi(p) {
-    ASSURE_THAT( p.width> 0.1, "Wedge is very narrow in phi < 0.1, not good idea")
+Wedge::Wedge( Reg phi, Reg z, Reg eta) 
+    : m_phi(phi) {
+    ASSURE_THAT( phi.width> 0.1, "Wedge is very narrow in phi < 0.1, not good idea")
     ASSURE_THAT( eta.width > 0.1, "Wedge is very narrow in eta < 0.1, not good idea (also do not support negative widths)")
-    ASSURE_THAT( std::fabs( eta.center + eta.width)> 0.01, "Wedge does not support eta + eta width == 0")
-    ASSURE_THAT( std::fabs( eta.center - eta.width)> 0.01, "Wedge does not support eta - eta width == 0")
+    ASSURE_THAT( std::fabs( eta.center + eta.width)> 0.01, "Wedge does not support eta + (eta width) ~= 0")
+    ASSURE_THAT( std::fabs( eta.center - eta.width)> 0.01, "Wedge does not support eta - (eta width) ~= 0")
     m_aleft = std::tan( 2.0 * std::atan( std::exp( - (eta.center-eta.width))));
     m_aright = std::tan( 2.0 * std::atan( std::exp( - (eta.center+eta.width))));
     m_bleft = - m_aleft/(z.center - z.width);
@@ -52,7 +52,12 @@ bool Wedge::in_wedge_r_phi_z( float r, float phi, float z ) const {
     }
     ASSURE_THAT( true, "Strange position of the point, does not fit any wedge definition");
     return false;
-
 }
 
 
+
+
+Reg region(float min, float max, uint8_t index, uint8_t splits ) {
+  float width = (max-min)/splits;
+  return {min + width*index + 0.5f*width, 0.5f*width};
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,4 +21,20 @@ target_link_libraries(AccumulatorSectionTest
   GTest::GTest)
 target_include_directories(AccumulatorSectionTest PRIVATE ../include)
 
-  add_test(AccumulatorSectionTest_getst AccumulatorSectionTest)  
+add_test(AccumulatorSectionTest_getst AccumulatorSectionTest)  
+
+
+add_executable(
+  ZPhiPartitioningTest
+  ZPhiPartitioningTestSuite.cpp
+  ../src/ZPhiPartitioning.cpp
+)
+
+target_link_libraries(ZPhiPartitioningTest
+ PRIVATE
+  GTest::GTest)
+target_include_directories(ZPhiPartitioningTest PRIVATE ../include)
+
+add_test(ZPhiPartitioningTest_getst ZPhiPartitioningTest)  
+
+

--- a/test/ZPhiPartitioningTestSuite.cpp
+++ b/test/ZPhiPartitioningTestSuite.cpp
@@ -46,7 +46,6 @@ TEST(PhiSuite, PhiWrappingAroundPI) {
   ASSERT_FALSE(wedge.in_wedge_r_phi_z(1, -3, 0));
 }
 
-
 // TEST(RZSuite, RightTilted) {
 //   Wedge wedge(Reg({0, 3.1415}), Reg({0, 20}), Reg({3, 1}) );
 //   std::cout << "Right\n";
@@ -59,13 +58,12 @@ TEST(PhiSuite, PhiWrappingAroundPI) {
 //   ASSERT_FALSE(wedge.in_wedge_r_phi_z(1, 1, -20));
 // }
 
-
 TEST(RZSuite, LeftTilted) {
   Wedge wedge(Reg({0, 3.1415}), Reg({0, 20}), Reg({-3, 1}) );
-  std::cout << "Left\n";
-  std::cout << "phi " << wedge.m_phi.center << " "  << wedge.m_phi.width << std::endl;
-  std::cout << "left " << wedge.m_aleft << " "  << wedge.m_bleft << std::endl;
-  std::cout << "right " << wedge.m_aright << " "  << wedge.m_bright << std::endl;
+  // std::cout << "Left\n";
+  // std::cout << "phi " << wedge.m_phi.center << " "  << wedge.m_phi.width << std::endl;
+  // std::cout << "left " << wedge.m_aleft << " "  << wedge.m_bleft << std::endl;
+  // std::cout << "right " << wedge.m_aright << " "  << wedge.m_bright << std::endl;
 
   ASSERT_FALSE(wedge.in_wedge_r_phi_z(1, 3.14, 20));
   // ASSERT_TRUE(wedge.in_wedge_r_phi_z(1, -3.14, 0));
@@ -91,7 +89,13 @@ TEST(RZSuite, Gen) {
 }
 
 
-
-
-
+TEST(SplitSuite, One) {
+  // Reg region(float min, float max, uint8_t index, uint8_t splits );
+  auto r1 = region(-3, 3, 0, 5);
+  ASSERT_FLOAT_EQ(r1.width, 0.5*6./5.);
+  ASSERT_FLOAT_EQ(r1.center, -3. + 0.5*6./5.);
+  auto r4 = region(-3, 3, 4, 5);
+  ASSERT_FLOAT_EQ(r4.width, 0.5*6./5.);
+  ASSERT_FLOAT_EQ(r4.center, 3. - 0.5*6./5.);
+}
 } // namespace HelixSolver


### PR DESCRIPTION
With the PR the input data is split into phi x eta (and z) wedges. 
It would allow parallelisation of the image searching process  (in various ways). 
By defa ile there is only one region, so everything works as before. 
FI @sh76909 