### PR TITLE
Events geo filtering

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,6 +23,9 @@
         "y_begin": 0.1,
         "y_end": 0.6
     },
+    "comment_regions": "specification is rmin, rmax, zmin, zmax. Example of two regions: [[0, 150, -550, 550],[0, 200, -900, -600]]",
     "excludeRZRegions": [[0, 150, -550, 550],[0, 200, -900, -600], [0, 200, 600, 900]],
+    "excludeEventsWithHitsInRZ": [[0, 200, -1600, -600], [0, 200, 600, 1600], [200,1200, -3000, -1200], [200,1200, 1200, 3000]],
+    "comment_excludeEventsWithHitsInRZ": "ODD specific: do not study events with hits in endcaps",
     "comment_excludeRZRegions": "ODD specific: remove 4 inner pixel barrel layers and 3 end-cap layers"
 }

--- a/include/HelixSolver/Application.h
+++ b/include/HelixSolver/Application.h
@@ -23,7 +23,7 @@ namespace HelixSolver
         static ComputingWorker::Platform getPlatformFromString(const std::string& platformStr);
         std::unique_ptr<std::vector<std::shared_ptr<Event>>> loadEventsFromSpacepointsRootFile(const std::string& path) const;
         static void saveSolutionsInRootFile(const std::unique_ptr<std::vector<ComputingWorker::EventSoutionsPair>>& eventsAndSolutions, const std::string& path);
-        std::function<bool(float, float, float)> selector () const;
+        std::function<bool(float, float, float)> selector (const std::string& settingName, bool defaultDecision = false) const;
 
         void loadConfig(const std::string& configFilePath);
     };

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -201,7 +201,7 @@ namespace HelixSolver
         hitsTree->SetBranchAddress("z", &z);
 
         std::map<Event::EventId, std::unique_ptr<std::vector<Point>>> points;
-        auto excludeRZRegions = selector("excludeRZRegions");
+        auto inExcludedRZRegions = selector("excludeRZRegions");
 
         for(int i = 0; hitsTree->LoadTree(i) >= 0; i++)
         {
@@ -210,7 +210,7 @@ namespace HelixSolver
             if( not config.contains("event") ||
                 (config.contains("event") && eventId == config["event"] ) ){  // to analyse only a single event add "event" property in config file
                 points.try_emplace(eventId, std::make_unique<std::vector<Point>>());
-                if ( not excludeRZRegions(x,y,z) ) {
+                if ( not inExcludedRZRegions(x,y,z) ) {
                     points[eventId]->push_back(Point{x, y, z, layer});
                     CDEBUG(DISPLAY_RPHI, std::hypot(x,y) << "," << std::atan2(y,x) << ":RPhi");
                 }


### PR DESCRIPTION
This adds option to exclude events that have hits in R-Z regions (for performance studies in the barrel).
Tagging @sh76909 